### PR TITLE
[codex] Keep daily RSS collection bounded and retryable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules/
 .snowpack/
 
 venv/
+.venv/
 __pycache__/
 
 # logs
@@ -30,5 +31,7 @@ netlify
 .idea/
 .vercel
 .playwright-mcp/
+.omc/
+.omx/
 
 workflow/test_resources/.env

--- a/workflow/article/blog.py
+++ b/workflow/article/blog.py
@@ -43,16 +43,13 @@ def make_daily_markdown_with(articles, rss_list):
     daily_guide = make_daily_guide(article_titles)
     if len(category_contents) == 0:
         logger.error("category content is empty!")
-        return
+        return False
     blog = Blog(metadata=meta_data, guide=daily_guide, categories=category_contents)
     logger.info(f"make blog success: {meta_data}")
-    # Don't write file if content is empty
-    if not category_contents:
-        logger.warning("No content generated, skipping file write")
-        return
     with open(md_path, "w") as fp:
         fp.write(blog.make_blog())
         logger.info(f"write to file: {md_path}")
+    return True
 
 
 def make_meta_data(description, tags):

--- a/workflow/article/rss.py
+++ b/workflow/article/rss.py
@@ -80,24 +80,25 @@ def load_rss_configs(resource):
 
 
 def parse_rss_config(rss_config):
-    """获取近期的 RSS 信息，默认覆盖最近 36 小时以兼容时区和 RSS 延迟。"""
+    """获取最近一个采集周期内的 RSS 信息，并限制在最近两个自然日内。"""
     res = feedparser.parse(rss_config["url"],
                            agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36")
     keymap = res.keymap
     today_rss = []
     # 默认一个rss源只获取一定数量信息
     max_count = rss_config.get("input_count", 4)
-    lookback_hours = int(rss_config.get("lookback_hours", os.environ.get("RSS_LOOKBACK_HOURS", 36)))
+    lookback_hours = int(rss_config.get("lookback_hours", os.environ.get("RSS_LOOKBACK_HOURS", 24)))
     time_zone = tz.gettz(time_zone_value)
     now = datetime.now(time_zone)
     start_time = now - timedelta(hours=lookback_hours)
+    allowed_dates = {now.date(), (now - timedelta(days=1)).date()}
 
     for article in res[keymap["items"]]:
         # issued > date > res.date
         article_date = unify_timezone(article.get(keymap["issued"],
                                                   article.get(keymap["date"],
                                                               res.get(keymap["date"]))))
-        if not article_date or not (start_time <= article_date <= now + timedelta(minutes=5)):
+        if not article_date or article_date.date() not in allowed_dates or not (start_time <= article_date <= now + timedelta(minutes=5)):
             continue
         rss = gen_article_from(rss_item=article, rss_type=rss_config.get("type"), image_enable=rss_config.get("image_enable", False),
                                rss_date=article_date.strftime("%Y-%m-%d %H:%M:%S"), channel=res[keymap["channel"]],

--- a/workflow/mainflow.py
+++ b/workflow/mainflow.py
@@ -17,7 +17,8 @@ def execute(rss_resource="workflow/resources"):
     if cache_folder:
         save_article(origin_article_list, cache_folder)
     articles = find_favorite_article(origin_article_list)
-    blog.make_daily_markdown_with(articles, origin_article_list)
+    if not blog.make_daily_markdown_with(articles, origin_article_list):
+        raise RuntimeError("Daily markdown was not generated because no article content was selected")
 
 
 def parse_daily_rss_article(rss_resource, cache_file=None):


### PR DESCRIPTION
## Summary

- Change RSS filtering to the recent 24-hour collection window while only accepting items from today or yesterday in Asia/Shanghai.
- Treat empty generated category content as a failed daily generation so GitHub Actions can retry instead of silently committing nothing.
- Ignore local OMX/Codex runtime folders and the local virtualenv folder.

## Why

The scheduled Action runs around the local day boundary. A strict same-day filter can drop valid previous-evening items, while the previous 36-hour window can pull in older content. The new window keeps the daily report continuous without widening too far.

## Validation

- `.venv/bin/python -m py_compile workflow/article/rss.py workflow/mainflow.py workflow/article/blog.py`
- Empty blog generation check returns `False` and logs `category content is empty!`

## Notes

Full live AI-backed collection was not rerun for this commit.